### PR TITLE
Pin image to latest Nginx version and latest Alpine version explicitly.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,5 @@ RUN npm run build-amaps
 
 
 # Web server image
-FROM nginx:1.12.2-alpine
+FROM nginx:1.25-alpine3.18
 COPY --from=build-deps /app/test /usr/share/nginx/html


### PR DESCRIPTION
The current docker image runs Alpine 3.5.2, whilst the update bumps Alpine to 3.18 (built one month ago). This should mitigate the many CVEs listed as Alpine 3.5.2 is too old.